### PR TITLE
Disable SSL Verification

### DIFF
--- a/CVE-2024-4577.py
+++ b/CVE-2024-4577.py
@@ -19,7 +19,7 @@ def check_vulnerability(domain, quiet):
         print(f"[!] Testing {domain}...")
         print("")
     try:
-        response = requests.post(url, headers=headers, data=data, timeout=10)
+        response = requests.post(url, headers=headers, data=data, timeout=10, verify=False)
         if "PHP Version" in response.text:
             print(f"{domain}: Vulnerable")
         elif not quiet:


### PR DESCRIPTION
verify=False will allow less errors due to SSL/TLS certificate verifications.